### PR TITLE
Fix: Windows Build Instructions

### DIFF
--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,7 +5,7 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. The instrictions below for windows can be used in Powershell/Command prompt but is recommended to do this in your wsl2 terminal on windows.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. In the instructions below for windows, It can be used in Powershell/Command prompt but is recommended to do this in your wsl2 terminal on windows.
 
 ```bash
 # Configure git NOTE: Change back To true after use if needed

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,12 +5,15 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. The instructions are below for windows. Make sure to be using the wsl2 terminal for the instructions.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to be using the wsl2 terminal if you are on windows or in the linux terminal for the instructions.
 
 ```bash
 # Clone and build
 git clone https://github.com/mborgerson/xemu.git
-docker run --rm -v $PWD/xemu:/xemu -w /xemu -e CCACHE_DIR=/xemu/ccache mborgerson/xemu-ubuntu-win64-cross:latest ./build.sh -p win64-cross
+docker run --rm -v $PWD/xemu:/xemu -w /xemu \
+    -e CCACHE_DIR=/xemu/ccache \
+    mborgerson/xemu-ubuntu-win64-cross:latest \
+    ./build.sh -p win64-cross
 
 # Run
 ./xemu/dist/xemu.exe

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,7 +5,7 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to remove back slashes " \ " in the build portion and make sure the build command is one line.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to remove back slashes \ in the build portion and make sure the build command is one line.
 
 ```bash
 # Configure git and change back To true after use if needed

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -8,7 +8,7 @@ Windows builds are cross-compiled from Ubuntu. If you would like to build *on* W
 documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to remove back slashes " \ " in the build portion and make sure the build command is one line.
 
 ```bash
-# Configure git (change back To true after use if needed)
+# Configure git and change back To true after use if needed
 git config --global core.autocrlf false
 
 # Clone and build

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,7 +5,7 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. In the instructions below for windows, It can be used in Powershell/Command prompt but is recommended to do this in your wsl2 terminal on windows.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. In the instructions below for windows, It can be used in Powershell/Command prompt but is recommended to do this in your WSL2 terminal on Windows.
 
 ```bash
 # Configure git NOTE: Change back To true after use if needed

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,7 +5,7 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to remove back slashes \ in the build portion and make sure the build command is one line.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to remove back slashes in the build portion and make sure the build command is one line.
 
 ```bash
 # Configure git and change back To true after use if needed

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,7 +5,7 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. The instrictions below for windows can be used in Powershell/Command prompt but is recommended to do this in your wsl2 terminal on windows.
 
 ```bash
 # Configure git NOTE: Change back To true after use if needed

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,18 +5,15 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to remove back slashes in the build portion and make sure the build command is one line.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up.
 
 ```bash
-# Configure git and change back To true after use if needed
+# Configure git NOTE: Change back To true after use if needed
 git config --global core.autocrlf false
 
 # Clone and build
 git clone --recurse-submodules https://github.com/mborgerson/xemu.git
-docker run --rm -v $PWD/xemu:/xemu -w /xemu \
-    -e CCACHE_DIR=/xemu/ccache \
-    mborgerson/xemu-ubuntu-win64-cross:latest \
-    ./build.sh -p win64-cross
+docker run --rm -v $PWD/xemu:/xemu -w /xemu -e CCACHE_DIR=/xemu/ccache mborgerson/xemu-ubuntu-win64-cross:latest ./build.sh -p win64-cross
 
 # Run
 ./xemu/dist/xemu.exe

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,11 +5,14 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. Make sure to remove back slashes " \ " in the build portion and make sure the build command is one line.
 
 ```bash
+# Configure git (change back To true after use if needed)
+git config --global core.autocrlf false
+
 # Clone and build
-git clone https://github.com/mborgerson/xemu.git
+git clone --recurse-submodules https://github.com/mborgerson/xemu.git
 docker run --rm -v $PWD/xemu:/xemu -w /xemu \
     -e CCACHE_DIR=/xemu/ccache \
     mborgerson/xemu-ubuntu-win64-cross:latest \

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -5,12 +5,9 @@ Users are recommended to use the [pre-built xemu binaries](https://github.com/mb
 ## Windows
 
 Windows builds are cross-compiled from Ubuntu. If you would like to build *on* Windows, you can use WSL2 and Docker. See [official Docker
-documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. In the instructions below for windows, It can be used in Powershell/Command prompt but is recommended to do this in your WSL2 terminal on Windows.
+documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get WSL2 and Docker set up. The instructions are below for windows. Make sure to be using the wsl2 terminal for the instructions.
 
 ```bash
-# Configure git NOTE: Change back To true after use if needed
-git config --global core.autocrlf false
-
 # Clone and build
 git clone --recurse-submodules https://github.com/mborgerson/xemu.git
 docker run --rm -v $PWD/xemu:/xemu -w /xemu -e CCACHE_DIR=/xemu/ccache mborgerson/xemu-ubuntu-win64-cross:latest ./build.sh -p win64-cross

--- a/docs/docs/building-from-source.md
+++ b/docs/docs/building-from-source.md
@@ -9,7 +9,7 @@ documentation](https://docs.docker.com/docker-for-windows/wsl/) for how to get W
 
 ```bash
 # Clone and build
-git clone --recurse-submodules https://github.com/mborgerson/xemu.git
+git clone https://github.com/mborgerson/xemu.git
 docker run --rm -v $PWD/xemu:/xemu -w /xemu -e CCACHE_DIR=/xemu/ccache mborgerson/xemu-ubuntu-win64-cross:latest ./build.sh -p win64-cross
 
 # Run


### PR DESCRIPTION
This Pr fixes the build instructions for Xemu on windows to build. At first, found out that when trying to use the build command it wouldn't execute unless the backslashes were removed so it was removed in this case and seems to scale fine on the site. It was not getting the right type of headers to be able to build within the docker that Xemu uses for building and by changing it to the one Linux uses made it build. noticing that having a problem getting the docker to start getting recurse-submodules and was able to build successfully.

Site:
![Screenshot 2022-02-03 161306](https://user-images.githubusercontent.com/64176728/152450582-af0f7e6d-59fc-4b24-93ed-9c1068a9cf0d.png)
 