### PR TITLE
SteamOS 3 dev Build Environment (via DistroBox)

### DIFF
--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -103,8 +103,6 @@ open ./dist/xemu.app
     export PATH=$PATH:/home/deck/.local/bin/
     export PATH=$PATH:/home/deck/.local/podman/bin/
     xhost +si:localuser:$USER
-
-    # !xhost is used to display programs with graphical interfaces. This only activates when running konsole. 
     
     # Installing Container 
     distrobox-create -i docker.io/library/archlinux:latest --name arch

--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -111,7 +111,7 @@ open ./dist/xemu.app
     distrobox-enter arch
     
     # Install dependencies
-    sudo pacman -S --needed --noconfirm git base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu python-yaml && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si && sudo pacman -S pipewire-pulse
+    sudo pacman -S --needed --noconfirm git base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu python-yaml libslirp && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si && sudo pacman -S pipewire-pulse
 
     # !During pulse audio install Select wireplumber
 

--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -98,7 +98,7 @@ open ./dist/xemu.app
     ```bash
     # Install DistroBox
     curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local && curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/extras/install-podman | sh -s -- --prefix ~/.local
-    # Go to .bashrc in kate and add at bottom line below.
+    # Go to home/deck/ and create a gile named .distroboxrc and in kate add whats below.
     export PATH=$PATH:/home/deck/.local/bin/
     export PATH=$PATH:/home/deck/.local/podman/bin/
     xhost +si:localuser:$USER

--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -93,6 +93,44 @@ open ./dist/xemu.app
     ./dist/xemu
     ```
 
+=== "SteamOS 3+ (Rootless)"
+
+    ```bash
+    # Install DistroBox
+    curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local && curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/extras/install-podman | sh -s -- --prefix ~/.local
+    # Go to .bashrc in kate and add at bottom line below.
+    export PATH=$PATH:/home/deck/.local/bin/
+    export PATH=$PATH:/home/deck/.local/podman/bin/
+    xhost +si:localuser:$USER
+
+    # !xhost is used to display programs with graphical interfaces. This only activates when running konsole. 
+    
+    # Installing Container 
+    distrobox-create -i docker.io/library/archlinux:latest --name arch
+
+    # Launch arch container.
+    distrobox-enter arch
+    
+    # Install dependencies
+    sudo pacman -S --needed --noconfirm git base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu python-yaml && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si && sudo pacman -S pipewire-pulse
+
+    # !During pulse audio install Select wireplumber
+
+    # Install an IDE/code editor (vscode)
+    yay -S visual-studio-code-bin --noconfirm
+
+    # export Code editor if it has a .desktop
+    distrobox-export --app code
+
+    # Clone and build
+    git clone --recurse-submodules https://github.com/xemu-project/xemu.git
+    cd xemu
+    ./build.sh
+
+    # Run
+    ./dist/xemu
+    ```
+
 !!! tip "Tip: Building with Clang, or another specific compiler"
 
     If you have multiple toolchains and would like to build with specific one,

--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -98,6 +98,7 @@ open ./dist/xemu.app
     ```bash
     # Install DistroBox
     curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --prefix ~/.local && curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/extras/install-podman | sh -s -- --prefix ~/.local
+    
     # Go to home/deck/ and create a gile named .distroboxrc and in kate add whats below.
     export PATH=$PATH:/home/deck/.local/bin/
     export PATH=$PATH:/home/deck/.local/podman/bin/


### PR DESCRIPTION
This adds a method for using a Steamdeck with steamOS 3.0 to be able to build and develop xemu in the desktop environment.