### PR TITLE
Include xdb as a submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/checkout@v3
       with:
-        repository: xemu-project/xdb
-        path: xdb
+        submodules: true
     - name: Build
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "xdb"]
+	path = xdb
+	url = git@github.com:xemu-project/xdb.git

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ xemu-website
 
 This repo contains the main website contents for the xemu original Xbox emulator with accompanying documentation and title information for compatibility reporting.
 
+### Cloning
+
+This repository must be cloned with submodules to pull the Xbox title repository.
+
+```sh
+$ git clone git@github.com:xemu-project/xemu-website.git --recurse-submodules
+```
+
+Or if already cloned, run `git submodules update --init --recursive`
+
 ### Build
 
 To build, simply run `rm -rf dist/ && DEV=1 ./build.sh` from within the project root.


### PR DESCRIPTION
Also updates build instructions to indicate that it is required.

An alternative to using a submodule is to have instructions to clone it manually, but I think a submodule is slightly cleaner.