### PR TITLE
Added libslirp-dev

### DIFF
--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -52,7 +52,7 @@ open ./dist/xemu.app
     ```bash
     # Install dependencies
     sudo apt update
-    sudo apt install git build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-yaml
+    sudo apt install git build-essential libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-yaml libslirp-dev
 
     # Clone and build
     git clone --recurse-submodules https://github.com/xemu-project/xemu.git


### PR DESCRIPTION
This is a needed package that is not in Ubuntu by default, so I have added it to the instructions.