### PR TITLE
Update troubleshooting.md: Replaced `sudo flatpak override ` with `flatpak override --user`

### DIFF
--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -19,7 +19,7 @@ As explained in the [readme](https://github.com/flathub/app.xemu.Xemu?tab=readme
 Note: This step is not necessary for other system files, such as the BIOS or the MCPX ROM.
 
 ### Flatpak
-1. `sudo flatpak override app.xemu.xemu --filesystem="$HOME/savedgames/xemu/`
+1. `flatpak override app.xemu.xemu --user --filesystem="$HOME/savedgames/xemu/`
 
 Note: Using the same command non-root with the `flatpak --user` parameter will not work.
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -21,8 +21,6 @@ Note: This step is not necessary for other system files, such as the BIOS or the
 ### Flatpak
 1. `flatpak override app.xemu.xemu --user --filesystem="$HOME/savedgames/xemu/`
 
-Note: Using the same command non-root with the `flatpak --user` parameter will not work.
-
 ### Flatseal
 1. Install [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal)
 2. Select <kbd>app.xemu.xemu</kbd>


### PR DESCRIPTION
# Recommended the `--user` flag instead of sudo

In my previous PR I added `sudo flatpak`:
* https://github.com/xemu-project/xemu-website/pull/157/files#diff-1327bca4414ff874a82cb31aec7614860723b2f79725bfbbfd71b2bf4d54ab67

After some research I found that flatpak overrides are usually documented with the --user flag, likely because not all users have root privileges.

Examples of other emulators who have documented the use of the `--user` flag:
* [Cemu](https://github.com/flathub/info.cemu.Cemu) (Wii U emulator): `flatpak override --user --filesystem=host info.cemu.Cemu`
* [PCSX2](https://github.com/flathub/net.pcsx2.PCSX2): `flatpak override --user net.pcsx2.PCSX2 --filesystem=/path/to/my/PS2_BIOS`

# Removed that the --user flag does not work

Removed: "Note: Using the same command non-root with the `flatpak --user` parameter will not work."

It didn't work for me before. But when I reinstalled everything it started working.
