### PR TITLE
Format compatibility reports box to make them easier to read

### DIFF
--- a/templates/template_title.html
+++ b/templates/template_title.html
@@ -18,6 +18,13 @@
   line-height: 1.5;
   border-radius: .25rem;
 }
+pre {
+  text-wrap: auto;
+  word-wrap: break-word;
+}
+pre > strong {
+  color: #62CA13;
+}
 </style>
 
 {% endblock %}
@@ -90,7 +97,7 @@
             {% endif %}
             </summary>
             <pre>
-{% for k in title.most_recent_test.info %}{{ k }}: {{ title.most_recent_test.info[k]|e }}
+{% for k in title.most_recent_test.info %}<strong>{{ k }}:</strong> {{ title.most_recent_test.info[k]|e }}
 {% endfor %}</pre>
           </details>
         </div>


### PR DESCRIPTION
A couple of changes to address #148:
- wrap text to fit the report box
- highlight field names

Before (desktop)
![before-desktop](https://github.com/user-attachments/assets/3039f800-dc2d-46d9-b6a5-2d2584610525)

After (desktop)
![after-desktop](https://github.com/user-attachments/assets/84acd9e9-4d17-49ae-b271-23ad9494946b)

Before (mobile)
![before-mobile](https://github.com/user-attachments/assets/01db7d03-7932-4aea-b090-8d2b30893d1d)

After (mobile)
![after-mobile](https://github.com/user-attachments/assets/2c493a77-1806-43ea-8615-683060e3a053)
