### PR TITLE
building-from-source.md: Fix debian dependencies

### DIFF
--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -53,7 +53,7 @@ open ./dist/xemu.app
     ```bash
     # Install dependencies
     sudo apt update
-    sudo apt install git build-essential cmake libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-pip python3-tomli python3-yaml libslirp-dev libvulkan-dev
+    sudo apt install git build-essential cmake libsdl2-dev libcurl4-gnutls-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-pip python3-tomli python3-yaml libslirp-dev libvulkan-dev
 
     # Clone and build
     git clone --recurse-submodules https://github.com/xemu-project/xemu.git

--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -53,7 +53,7 @@ open ./dist/xemu.app
     ```bash
     # Install dependencies
     sudo apt update
-    sudo apt install git build-essential cmake libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-yaml libslirp-dev libvulkan-dev
+    sudo apt install git build-essential cmake libsdl2-dev libepoxy-dev libpixman-1-dev libgtk-3-dev libssl-dev libsamplerate0-dev libpcap-dev ninja-build python3-pip python3-tomli python3-yaml libslirp-dev libvulkan-dev
 
     # Clone and build
     git clone --recurse-submodules https://github.com/xemu-project/xemu.git


### PR DESCRIPTION
Due to the whole venv thing with later revs of Ubuntu, PopOS and Debian, instead of just forcing venv to be disabled, install the venv package, also enforce pip installation due to reliance on tomli, and install python3-tomli, this fixes debian on later releases of python and debian/ubuntu