### PR TITLE
Fix arch install instructions by including missing packages

### DIFF
--- a/docs/docs/dev/building-from-source.md
+++ b/docs/docs/dev/building-from-source.md
@@ -68,7 +68,7 @@ open ./dist/xemu.app
 
     ```bash
     # Install dependencies
-    sudo pacman -S --noconfirm git base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu python-yaml libslirp
+    sudo pacman -S --noconfirm git base-devel sdl2 libepoxy pixman gtk3 openssl libsamplerate libpcap ninja glu python-yaml libslirp cmake vulkan-headers
 
     # Clone and build
     git clone --recurse-submodules https://github.com/xemu-project/xemu.git


### PR DESCRIPTION
I'm unable to build on Arch via the current install instructions. Upon installing the cmake and vulkan-headers packages, I was able to build from source easily. This PR adds those packages to the instructions.